### PR TITLE
chore: Fix the upload workflow and the list of authors

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Build package
         run: |
+          python3 setup.py build_py
           python3 setup.py sdist bdist_wheel
 
       - name: Publish package to PyPI
@@ -32,7 +33,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          OUTPUT=$(python3 -m twine upload dist/* 2>&1) || true
+          OUTPUT=$(python3 -m twine upload dist/* 2>&1)
           if echo "$OUTPUT" | grep -q "File already exists"; then
             echo "Package version already exists. Skipping further steps."
             exit 0

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -32,4 +32,11 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          python3 -m twine upload dist/*
+          OUTPUT=$(python3 -m twine upload dist/* 2>&1) || true
+          if echo "$OUTPUT" | grep -q "File already exists"; then
+            echo "Package version already exists. Skipping further steps."
+            exit 0
+          else
+            echo "$OUTPUT"
+            exit 1
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,8 @@
 [project]
 name = "pylego"
-version = "0.1.0"
+version = "0.1.2"
 authors = [
-  { name="Ghislain Bourgeois", email="ghislain.bourgeois@canonical.com" },
-  { name="Kayra Gemalmaz", email="kayra.gemalmaz@canonical.com" },
-  { name="Daniel Arndt", email="daniel.arndt@canonical.com" },
-  { name="Guillaume Belanger", email="guillaume.belanger@canonical.com" },
-  { name="Yazan Salti", email="yazan.salti@canonical.com" },
+  { name="Canonical", email="telco-engineers@lists.canonical.com" },
 ]
 description = "A python wrapper package for the lego application written in Golang"
 readme = "README.md"


### PR DESCRIPTION
# Description

`setuptools` does not seem to allow a list of authors. I followed some examples [in](https://github.com/canonical/pylxd/blob/main/setup.cfg#L7) and went with Canonical as the author and the telco mailing list as the email.
There are some minor fixes too:
- Renames the file to be consistent with the command name
- Adds a check not to fail if the package was already published
- Version is bumped and ready to publish with the new info

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the version of the package in pyproject.toml
