### PR TITLE
fix: Fixes the upload command

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -33,7 +33,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          OUTPUT=$(python3 -m twine upload --verbose dist/* 2>&1)
+          OUTPUT=$(python3 -m twine upload --verbose dist/* 2>&1) || true
           if echo "$OUTPUT" | grep -q "File already exists"; then
             echo "Package version already exists. Skipping further steps."
             exit 0


### PR DESCRIPTION
# Description

Force the script to go on even if the command fails to be able to handle the case when the failure is due to the file being already uploaded.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version of the package in pyproject.toml
