### PR TITLE
chore: better package imports

### DIFF
--- a/src/pylego/__init__.py
+++ b/src/pylego/__init__.py
@@ -1,1 +1,1 @@
-from .pylego import run_lego_command  # noqa: F401, D104
+from .pylego import LEGOError, LEGOResponse, run_lego_command  # noqa: F401, D104


### PR DESCRIPTION
# Description

This PR makes it so we can import the 2 classes from the top level namespace.
right now we have to do:
 ```bash
from pylego import run_lego_command
```
or

```bash
from pylego.pylego import run_lego_command, LEGOError, LEGOResponse
```
with this we can do
```bash
from pylego import run_lego_command, LEGOError, LEGOResponse
```

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the version of the package in pyproject.toml
