### PR TITLE
chore: pick subdirectory for golang dependabot updates and bump go version

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,7 +12,7 @@ updates:
           - "*"
 
   - package-ecosystem: "gomod"
-    directory: "/"
+    directory: "/src/pylego"
     schedule:
       interval: "weekly"
     commit-message:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylego"
-version = "0.1.6"
+version = "0.1.7"
 authors = [
   { name="Canonical", email="telco-engineers@lists.canonical.com" },
 ]

--- a/src/pylego/go.mod
+++ b/src/pylego/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/pylego
 
-go 1.22.5
+go 1.23
 
 require github.com/go-acme/lego/v4 v4.17.4
 


### PR DESCRIPTION
# Description

This PR bumps the Go version from 1.22.5 to 1.23, and moves the directory defined by the dependabot for go updates to the directory that contains go.mod and go.sum

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the version of the package in pyproject.toml
