### PR TITLE
build: Add logging lint checks to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylego"
-version = "0.1.8"
+version = "0.1.9"
 authors = [
   { name="Canonical", email="telco-engineers@lists.canonical.com" },
 ]
@@ -42,7 +42,19 @@ pylego = ["lego.so", "lego.go", "go.mod", "go.sum"]
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "C", "N", "D", "I001"]
+select = [
+    "E",
+    "W",
+    "F",
+    "C",
+    "N",
+    "D",
+    "I001",
+    "G001",  # Logging statement uses str.format
+    "G002",  # Logging statement uses %
+    "G003",  # Logging statement uses +
+    "G004",  # Logging statement uses an f-string
+]
 extend-ignore = [
     "D203",
     "D204",


### PR DESCRIPTION
Checks for some common logging patterns to avoid.

It doesn't seem like these settings are actually used anywhere by this project, but I wanted to keep `pyproject.toml` consistent with our other projects.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version of the package in pyproject.toml
