### PR TITLE
fix: Fix Renovate configuration for bumping the version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,15 +45,5 @@
       groupName: 'Python dependencies',
     },
   ],
-  postUpgradeTasks: {
-    commands: [
-      "current_version=$(grep '^version = ' pyproject.toml | sed 's/version = \"\\(.*\\)\"/\\1/')",
-      "new_version=$(echo $current_version | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')",
-      'sed -i "s/^version = \\".*\\"/version = \\"$new_version\\"/" pyproject.toml',
-    ],
-    fileFilters: [
-      'pyproject.toml',
-    ],
-    executionMode: 'update',
-  },
+  bumpVersion: "patch",
 }


### PR DESCRIPTION
# Description

The Renovate configuration for bumping the version of the package is currently broken. We used `postUpgradeTasks`, but the documentation now says that it is only supported when using Renovate self-hosted. It prevents Renovate PRs from passing checks.

This PR uses the `bumpVersion` field: https://docs.renovatebot.com/configuration-options/#bumpversion

The documentation is a bit contradictory, as the table does not list `pep621` as a supported manager, but the description does.

This PR will need to be merged to test the behavior.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version of the package in pyproject.toml
