### PR TITLE
feat: Allow passing a private key when running the lego command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,17 @@ You can import the lego command and run any function that you can run from the C
 ```python
 from pylego import run_lego_command
 test_env = {"NAMECHEAP_API_USER": "user", "NAMECHEAP_API_KEY": "key"}
-run_lego_command("something@gmail.com", "https://localhost/directory", "-----BEGIN CERTIFICATE REQUEST----- ...", "namecheap", test_env)
+run_lego_command("something@gmail.com", "https://localhost/directory", "-----BEGIN CERTIFICATE REQUEST----- ...", "namecheap", test_env, "-----BEGIN RSA PRIVATE KEY-----")
 ```
 
 | Argument | Description                                                                                                                                                                                                                                                  |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `email`  | The provided email will be registered to LetsEncrypt. It may receive some emails notifying the user about certificate expiry.                                                                                                                                |
+| `email`  | The provided email will be registered to the ACME server. It may receive some emails notifying the user about certificate expiry.                                                                                                                                |
 | `server` | This is the full URL of a server that implements the ACME protocol. While letsencrypt is the most common one, there are other programs that provide this facility like Vault.                                                                                |
 | `csr`    | This must be a PEM string in bytes that is user generated and valid as according to the ACME server that is being provided above. Many providers have different requirements for what is allowed to be in the fields of the CSR.                             |
 | `plugin` | The plugin is a string that's supported by LEGO. The full list is located [here](https://go-acme.github.io/lego/dns/). On top of the LEGO provided ones, we have an extra plugin called `http` that will allow users to use HTTP01 and TLSALPN01 challenges. |
 | `env`    | The env is a dictionary mapping of strings to strings that will be loaded into the environment for LEGO to use. All plugins require some configuration values loaded into the environment. You can find them [here](https://go-acme.github.io/lego/dns/)     |
+| `private_key`    | The provided private key will be used to register the user to the ACME server, if not provided pylego will generate a new one  |
 
 On top of the environment variables that LEGO supports, we have some extra ones that we use to configure the library:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylego"
-version = "0.1.23"
+version = "0.1.24"
 authors = [
   { name="Canonical", email="telco-engineers@lists.canonical.com" },
 ]

--- a/src/pylego/lego.go
+++ b/src/pylego/lego.go
@@ -23,11 +23,12 @@ import (
 )
 
 type LegoInputArgs struct {
-	Email  string `json:"email"`
-	Server string `json:"server"`
-	CSR    string `json:"csr"`
-	Plugin string `json:"plugin"`
-	Env    map[string]string
+	Email      string `json:"email"`
+	PrivateKey string `json:"private_key,omitempty"`
+	Server     string `json:"server"`
+	CSR        string `json:"csr"`
+	Plugin     string `json:"plugin"`
+	Env        map[string]string
 }
 
 type LegoOutputResponse struct {
@@ -56,7 +57,7 @@ func RunLegoCommand(message *C.char) *C.char {
 		}
 
 	}
-	certificate, err := requestCertificate(CLIArgs.Email, CLIArgs.Server, CLIArgs.CSR, CLIArgs.Plugin)
+	certificate, err := requestCertificate(CLIArgs.Email, CLIArgs.PrivateKey, CLIArgs.Server, CLIArgs.CSR, CLIArgs.Plugin)
 	if err != nil {
 		return C.CString(fmt.Sprint("error: couldn't request certificate: ", err))
 	}
@@ -68,10 +69,20 @@ func RunLegoCommand(message *C.char) *C.char {
 	return return_message_ptr
 }
 
-func requestCertificate(email, server, csr, plugin string) (*LegoOutputResponse, error) {
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't generate priv key: %s", err)
+func requestCertificate(email, privateKeyPem, server, csr, plugin string) (*LegoOutputResponse, error) {
+	var privateKey crypto.PrivateKey
+	if privateKeyPem != "" {
+		parsedKey, err := certcrypto.ParsePEMPrivateKey([]byte(privateKeyPem))
+		if err != nil {
+			return nil, fmt.Errorf("couldn't parse private key: %s", err)
+		}
+		privateKey = parsedKey
+	} else {
+		generatedKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't generate priv key: %s", err)
+		}
+		privateKey = generatedKey
 	}
 	user := LetsEncryptUser{
 		Email: email,

--- a/src/pylego/pylego.py
+++ b/src/pylego/pylego.py
@@ -35,7 +35,7 @@ class LEGOError(Exception):
 
 
 def run_lego_command(
-    email: str, server: str, csr: bytes, env: dict[str, str], plugin: str = ""
+    email: str, server: str, csr: bytes, env: dict[str, str], plugin: str = "", private_key: str = ""
 ) -> LEGOResponse:
     """Run an arbitrary command in the Lego application. Read more at https://go-acme.github.io.
 
@@ -45,6 +45,7 @@ def run_lego_command(
         csr: the csr to be signed
         plugin: which DNS provider plugin to use for the request. Find yours at https://go-acme.github.io/lego/dns/.
         env: the environment variables required for the chosen plugin.
+        private_key: the private key to be used for the request. If not provided, a new one will be generated.
     """
     library.RunLegoCommand.restype = ctypes.c_char_p
     library.RunLegoCommand.argtypes = [ctypes.c_char_p]
@@ -57,6 +58,7 @@ def run_lego_command(
                 "csr": csr.decode(),
                 "plugin": plugin,
                 "env": env,
+                "private_key": private_key,
             }
         ),
         "utf-8",

--- a/tests/integration/test_pylego.py
+++ b/tests/integration/test_pylego.py
@@ -44,6 +44,7 @@ class TestPyLego:
                 "HTTP01_PORT": "5002",
                 "TLSALPN01_PORT": "5001",
             },
+            private_key="whatever private key",
         )
         assert response.metadata.domain == "localhost"
 


### PR DESCRIPTION
# Description

This PR allows passing a private key in `run_lego_command` the private key is used to register a user alongside the email address when requesting a new certificate from the acme server.
If the private key is not provided the old mechanism of generating a new private key will be used.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the version of the package in pyproject.toml
