### PR TITLE
fix: Fix the condition to run the upload workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,12 +17,31 @@ jobs:
     uses: ./.github/workflows/test-package.yaml
   test-build:
     uses: ./.github/workflows/build-package.yaml
+  check-src-changes:
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'main'
+    outputs:
+      src_changed: ${{ steps.src-check.outputs.src_changed }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: check if src files changed
+        id: src-check
+        run: |
+          if git diff --name-only HEAD~1 HEAD | grep -q "^src/"; then
+            echo "src_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "src_changed=false" >> $GITHUB_OUTPUT
+          fi
   upload-package:
     needs:
       - test-package
       - test-build
+      - check-src-changes
     if: |
       github.ref_name == 'main' &&
-      needs.test-package.outputs.src_changed == 'true'
+      needs.check-src-changes.outputs.src_changed == 'true'
     uses: ./.github/workflows/upload.yaml
     secrets: inherit


### PR DESCRIPTION
# Description

We check if the PR has a change in any file under `src/` in the `test_package` workflow and if that was the case we bump the version of pylego. And then we use that condition to run the `upload` workflow however that will never be true because when we merge the PR it doesn't exist as a PR anymore. Here we change the condition for `upload` to check if any file being merged is under `src/`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version of the package in pyproject.toml
