### PR TITLE
fix: Downgrade python to 3.12

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "A python wrapper package for the lego application written in Golang"
 readme = "README.md"
-requires-python = ">=3.13.3"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/uv.lock
+++ b/uv.lock
@@ -82,7 +82,7 @@ wheels = [
 
 [[package]]
 name = "pylego"
-version = "0.1.23"
+version = "0.1.24"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
# Description

Downgrading python to `>=3.10` for compatibility with Ubuntu-24.04

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version of the package in pyproject.toml
