### PR TITLE
fix: Revert python version bump and disable future upgrades by renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,48 +1,39 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    'config:recommended',
-    ':disableRateLimiting',
-    ':noUnscheduledUpdates',
-    ':semanticCommits',
+    "config:recommended",
+    ":disableRateLimiting",
+    ":noUnscheduledUpdates",
+    ":semanticCommits",
   ],
   automerge: true,
-  automergeStrategy: 'squash',
-  automergeType: 'pr',
+  automergeStrategy: "squash",
+  automergeType: "pr",
   platformAutomerge: true,
-  schedule: [
-    'after 1am and before 3am on monday',
-  ],
-  timezone: 'Etc/UTC',
-  enabledManagers: [
-    'github-actions',
-    'gomod',
-    'pep621',
-  ],
+  schedule: ["after 1am and before 3am on monday"],
+  timezone: "Etc/UTC",
+  enabledManagers: ["github-actions", "gomod", "pep621"],
   packageRules: [
     {
-      matchManagers: [
-        'github-actions',
-      ],
-      groupName: 'github_actions',
-      commitMessagePrefix: 'chore: ',
+      matchManagers: ["github-actions"],
+      groupName: "github_actions",
+      commitMessagePrefix: "chore: ",
     },
     {
-      matchManagers: [
-        'gomod',
-      ],
-      matchFileNames: [
-        'src/pylego/**',
-      ],
-      groupName: 'go_dependencies',
-      commitMessagePrefix: 'chore: ',
+      matchManagers: ["gomod"],
+      matchFileNames: ["src/pylego/**"],
+      groupName: "go_dependencies",
+      commitMessagePrefix: "chore: ",
     },
     {
-      matchManagers: [
-        'pep621',
-      ],
-      rangeStrategy: 'bump',
-      groupName: 'Python dependencies',
+      matchManagers: ["pep621"],
+      rangeStrategy: "bump",
+      groupName: "Python dependencies",
+    },
+    {
+      // Disable updating Python, should be done when updating the Ubuntu base
+      matchPackageNames: ["python"],
+      enabled: false,
     },
   ],
   bumpVersion: "patch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "pylego"
-version = "0.1.28"
+version = "0.1.29"
 authors = [
   { name="Canonical", email="telco-engineers@lists.canonical.com" },
 ]
 description = "A python wrapper package for the lego application written in Golang"
 readme = "README.md"
-requires-python = ">=3.13.7"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
# Description

Revert python version bump and disable future upgrades by renovate

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated the version of the package in pyproject.toml
